### PR TITLE
Add the 'debug' cmdline parameter to pppd unconditionally

### DIFF
--- a/pppd.py
+++ b/pppd.py
@@ -75,6 +75,7 @@ class PPPConnection:
             commands.append(v)
         commands.extend(args)
         commands.append('nodetach')
+        commands.append('debug')
 
         self.proc = Popen(commands, 
             stdout=PIPE, 


### PR DESCRIPTION
To detect whether the connection has been established, the code relies on 'ip-up finished' being in pppd output, which it only outputs when run in debug mode: https://github.com/ppp-project/ppp/blob/04e6b8dde02a25d765cca3ff5e7ba03887346c6f/pppd/main.c#L2038